### PR TITLE
Fix: remove the article status model and add an enum to articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -40,14 +40,14 @@ class ArticlesController < ApplicationController
   end
 
   private
-  
-    # Use callbacks to share common setup or constraints between actions.
-    def set_article
-      @article = Article.find(params[:id])
-    end
 
-    # Only allow a trusted parameter "white list" through.
-    def article_params
-      params.require(:article).permit(:title, :user_id, :featured, :spotlighted, :content, :feature_image, :article_status_id)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_article
+    @article = Article.find(params[:id])
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def article_params
+    params.require(:article).permit(:title, :user_id, :featured, :spotlighted, :content, :feature_image, :status)
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,9 +1,8 @@
 class Article < ApplicationRecord
   belongs_to :user
-  belongs_to :article_status
 
-  alias_attribute :status, :article_status
   def slug
     title.parameterize
   end
+  enum status: [:draft, :published, :archived]
 end

--- a/app/models/article_status.rb
+++ b/app/models/article_status.rb
@@ -1,2 +1,0 @@
-class ArticleStatus < ApplicationRecord
-end

--- a/db/migrate/20160927204953_create_article_statuses.rb
+++ b/db/migrate/20160927204953_create_article_statuses.rb
@@ -1,9 +1,0 @@
-class CreateArticleStatuses < ActiveRecord::Migration[5.0]
-  def change
-    create_table :article_statuses do |t|
-      t.string :title
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20160927205044_add_article_status_to_article.rb
+++ b/db/migrate/20160927205044_add_article_status_to_article.rb
@@ -1,5 +1,0 @@
-class AddArticleStatusToArticle < ActiveRecord::Migration[5.0]
-  def change
-    add_reference :articles, :article_status, foreign_key: true
-  end
-end

--- a/db/migrate/20160927211620_add_non_null_to_article_statuses_title.rb
+++ b/db/migrate/20160927211620_add_non_null_to_article_statuses_title.rb
@@ -1,5 +1,0 @@
-class AddNonNullToArticleStatusesTitle < ActiveRecord::Migration[5.0]
-  def change
-    change_column :article_statuses, :title, :string, null: false
-  end
-end

--- a/db/migrate/20160928191359_add_status_enum_to_article.rb
+++ b/db/migrate/20160928191359_add_status_enum_to_article.rb
@@ -1,0 +1,5 @@
+class AddStatusEnumToArticle < ActiveRecord::Migration[5.0]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20160928191930_add_default_non_null_to_article_status.rb
+++ b/db/migrate/20160928191930_add_default_non_null_to_article_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultNonNullToArticleStatus < ActiveRecord::Migration[5.0]
+  def change
+    change_column :articles, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,28 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927211620) do
+ActiveRecord::Schema.define(version: 20160928191930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "article_statuses", force: :cascade do |t|
-    t.string   "title",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "articles", force: :cascade do |t|
-    t.string   "title",                             null: false
+    t.string   "title",                         null: false
     t.integer  "user_id"
-    t.boolean  "featured",          default: false
-    t.boolean  "spotlighted",       default: false
-    t.text     "content",                           null: false
+    t.boolean  "featured",      default: false
+    t.boolean  "spotlighted",   default: false
+    t.text     "content",                       null: false
     t.string   "feature_image"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.integer  "article_status_id"
-    t.index ["article_status_id"], name: "index_articles_on_article_status_id", using: :btree
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "status",        default: 0,     null: false
     t.index ["user_id"], name: "index_articles_on_user_id", using: :btree
   end
 
@@ -55,5 +48,4 @@ ActiveRecord::Schema.define(version: 20160927211620) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
-  add_foreign_key "articles", "article_statuses"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,3 @@
-ArticleStatus.create(
-  title: 'Draft'
-)
-ArticleStatus.create(
-  title: 'Published'
-)
-ArticleStatus.create(
-  title: 'Archived'
-)
 User.create(
   name: 'David Harris',
   email: 'forbiddenvoid@gmail.com',
@@ -48,6 +39,7 @@ User.create(
 #   ]
 # }
 #
+statuses = *(0..2)
 featured_count = 0
 10.times do
   title = FFaker::HealthcareIpsum.words.map(&:capitalize).join(' ')
@@ -60,10 +52,10 @@ featured_count = 0
   end
   Article.create(
     user: User.all.sample,
-    status: ArticleStatus.all.sample,
     title: title,
     featured: featured,
     spotlighted: featured,
+    status: statuses.sample,
     content: FFaker::HealthcareIpsum.paragraphs,
     feature_image: FFaker::Avatar.image
   )

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Article, type: :model do
   describe 'Associations' do
     it { should belong_to(:user) }
-    it { should belong_to(:article_status) }
   end
   it 'is not valid without a title' do
     expect(
@@ -14,5 +13,10 @@ RSpec.describe Article, type: :model do
     expect(
       Article.new(title: 'Hello World')
     ).to_not be_valid
+  end
+  it 'sets the status to draft by default' do
+    expect(
+      Article.new.status
+    ).to eq('draft')
   end
 end

--- a/spec/models/article_status_spec.rb
+++ b/spec/models/article_status_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ArticleStatus, type: :model do
-  describe 'has title column' do
-    it { should have_db_column(:title).of_type(:string).with_options(null: false) }
-  end
-end


### PR DESCRIPTION
- Remove the article status model
- Add a status enum to article with
  - Draft (default)
  - published
  - Archived
- Update seeds and tests to pass with new configuration