### PR TITLE
Feat send email notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dm.sh
 !/tmp/.keep
 
 .idea/
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'pundit'
 gem 'active_model_serializers'
+
+gem 'dotenv-rails', :groups => [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     equalizer (0.0.11)
     erubis (2.7.0)
     factory_girl (4.7.0)
@@ -241,6 +245,7 @@ DEPENDENCIES
   byebug
   database_cleaner (~> 1.5.3)
   devise
+  dotenv-rails
   factory_girl_rails
   ffaker
   listen (~> 3.0.5)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'udacity-alumni@udacity.com'
   layout 'mailer'
 end

--- a/app/mailers/new_user_signup_mailer.rb
+++ b/app/mailers/new_user_signup_mailer.rb
@@ -1,0 +1,8 @@
+class NewUserSignupMailer < ApplicationMailer
+
+  def welcome_email(user)
+    @user = user
+    mail(to: @user.email, subject: "Thank you for joining Udacity alumni network!" )
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   before_create :generate_auth_token!
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -10,6 +11,8 @@ class User < ApplicationRecord
 
   before_save { self.email = email.downcase }
   after_initialize :set_default_role
+  after_create :send_welcome_email
+
   validates :auth_token, uniqueness: true
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
@@ -26,4 +29,9 @@ class User < ApplicationRecord
   def set_default_role
     self.role ||= :user if self.new_record?
   end
+
+  def send_welcome_email
+    NewUserSignupMailer.welcome_email(self).deliver_now
+  end
+
 end

--- a/app/views/new_user_signup_mailer/welcome_email.html.erb
+++ b/app/views/new_user_signup_mailer/welcome_email.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+
+  <body>
+  <h1>Welcome to Udacity Alumni network, <%= @user.name %>!</h1>
+  <p>Thanks for joining and have a great day! Now sign in and do
+    awesome things!</p>
+  </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,9 +26,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
@@ -37,11 +34,25 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # ActionMailer config
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+      user_name: ENV['SENDGRID_USERNAME'],
+      password: ENV['SENDGRID_PASSWORD'],
+      domain: 'heroku.com',
+      address: 'smtp.sendgrid.net',
+      port: 587,
+      authentication: :plain,
+      enable_starttls_auto: true
+  }
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,18 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # ActionMailer config
+  config.action_mailer.default_url_options = { host: 'http://www.udacity.com' } # TODO update host
+  config.action_mailer.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+      user_name: ENV['SENDGRID_USERNAME'],
+      password: ENV['SENDGRID_PASSWORD'],
+      domain: 'heroku.com',
+      address: 'smtp.sendgrid.net',
+      port: 587,
+      authentication: :plain,
+      enable_starttls_auto: true
+  }
+
 end

--- a/spec/mailers/new_user_signup_spec.rb
+++ b/spec/mailers/new_user_signup_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe NewUserSignupMailer, type: :mailer do
+  before(:each) do
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+    @user = create(:user, email: "user@example.com")
+    NewUserSignupMailer.welcome_email(@user).deliver_now
+  end
+
+  after(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it 'renders the receiver email' do
+    expect(ActionMailer::Base.deliveries.first.to).to eq(["user@example.com"])
+  end
+
+  it 'should set the subject to the correct subject' do
+    expect(ActionMailer::Base.deliveries.first.subject).to eq('Thank you for joining Udacity alumni network!')
+  end
+
+  it 'renders the sender email' do
+    expect(ActionMailer::Base.deliveries.first.from).to eq(["udacity-alumni@udacity.com"])
+  end
+
+end

--- a/spec/mailers/previews/new_user_signup_preview.rb
+++ b/spec/mailers/previews/new_user_signup_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/new_user_signup
+class NewUserSignupPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
- Add-on SendGrid email service on Heroku
- setup ActionMailer config in dev and prod env
- install .env to hide SendGrid username and password
- trigger welcome email callback when user is created
- create welcome email in html format
- create RSpec 3 ActionMailer tests